### PR TITLE
Tested plugin with osCommerce Phoenix version v1.0.7.10

### DIFF
--- a/README_Phoenix.md
+++ b/README_Phoenix.md
@@ -7,7 +7,7 @@ Released under the GPL V3 license: https://opensource.org/licenses/GPL-3.0
 
 ## Supported osCommerce versions
 
-*The plugin has been tested with osCommerce CE Phoenix v1.0.7.4
+*The plugin has been tested with osCommerce CE Phoenix v1.0.7.10
 
 ## Installation
 

--- a/README_Phoenix.md
+++ b/README_Phoenix.md
@@ -7,7 +7,7 @@ Released under the GPL V3 license: https://opensource.org/licenses/GPL-3.0
 
 ## Supported osCommerce versions
 
-*The plugin has been tested with osCommerce CE Phoenix v1.0.7.10
+*The plugin has been tested with osCommerce CE Phoenix up to v1.0.7.10
 
 ## Installation
 


### PR DESCRIPTION
Starting from osCommerce Phoenix version v1.0.7.09 there were introduced breaking changes for payment gateway plugins.
Tested the plugin with the osCommerce Phoenix version v1.0.7.10 and everything works as expected.